### PR TITLE
Direct WebLogic download links

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -5,7 +5,7 @@ This demo shows how you can deploy a Java EE application to Azure into a WebLogi
 
 * Install the latest version of Oracle JDK 8 (we used [8u241](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)).
 * Install the Eclipse IDE for Enterprise Java Developers from [here](https://www.eclipse.org/downloads/packages/).
-* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://www.oracle.com/middleware/technologies/weblogic-server-downloads.html). You need this locally even if you are not running WebLogic locally because the Eclipse WebLogic deployment support needs it.
+* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://download.oracle.com/otn/nt/middleware/12c/12213/fmw_12.2.1.3.0_wls_quick_Disk1_1of1.zip). You need this locally even if you are not running WebLogic locally because the Eclipse WebLogic deployment support needs it.
 * Download this repository somewhere in your file system (easiest way might be to download as a zip and extract).
 * You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/en-us/free).
 

--- a/javaee/README.md
+++ b/javaee/README.md
@@ -7,7 +7,7 @@ We use Eclipse but you can use any Maven and WebLogic capable IDE such as NetBea
 
 * Install the latest version of Oracle JDK 8 (we used [8u241](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)).
 * Install the Eclipse IDE for Enterprise Java Developers from [here](https://www.eclipse.org/downloads/packages/).
-* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://www.oracle.com/middleware/technologies/weblogic-server-downloads.html).
+* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://download.oracle.com/otn/nt/middleware/12c/12213/fmw_12.2.1.3.0_wls_quick_Disk1_1of1.zip).
    * **preview** use `60a78f02.microsoft.com@amer.teams.ms` and `hEc!ucesW3Th` for the credentials
 * Download this repository somewhere in your file system (easiest way might be to download as a zip and extract).
 * You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/en-us/free).

--- a/simple/README.md
+++ b/simple/README.md
@@ -5,7 +5,7 @@ This demo shows how you can deploy a Java EE application to Azure using a simple
 
 * Install the latest version of Oracle JDK 8 (we used [8u241](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)).
 * Install the Eclipse IDE for Enterprise Java Developers from [here](https://www.eclipse.org/downloads/packages/).
-* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://www.oracle.com/middleware/technologies/weblogic-server-downloads.html).  You need this locally even if you are not running WebLogic locally because the Eclipse WebLogic deployment support needs it.
+* Install WebLogic 12.2.1.3 using the Quick Installer by downloading it from [here](https://download.oracle.com/otn/nt/middleware/12c/12213/fmw_12.2.1.3.0_wls_quick_Disk1_1of1.zip).  You need this locally even if you are not running WebLogic locally because the Eclipse WebLogic deployment support needs it.
 * Download this repository somewhere in your file system (easiest way might be to download as a zip and extract).
 * You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/en-us/free).
 


### PR DESCRIPTION
Linking to the WebLogic download page creates a significant likelyhood that attendees will download version 14 of WebLogic, which is listed at the top.

I've changed the links to go directly to the download of the 12.2.1.3 quick installer.